### PR TITLE
Resolve merge conflicts and fix broken JSX in analytics, mood and transactions pages

### DIFF
--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -22,6 +22,7 @@ import {
   Legend,
 } from 'recharts'
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 	// Analytics page component
 export default function Analytics() {
@@ -113,8 +114,8 @@ export default function Analytics() {
   }
 
   return (
-	{/* Page header with period selector */}
     <Layout>
+      {/* Page header with period selector */}
       <div className="space-y-8">
         <div className="flex justify-between items-center">
           <h1 className="text-3xl font-bold tracking-tight">Analytics</h1>

--- a/src/pages/mood-analytics.tsx
+++ b/src/pages/mood-analytics.tsx
@@ -101,13 +101,8 @@ const formatDate = (dateStr: string) => {
     }).format(date);
   }
 };
-<<<<<<< HEAD
 // Custom tooltip component for mood trend chart
-const CustomTooltip = ({ active, payload, label }: any) => {
-=======
-
 const CustomTooltip = ({ active, payload }: any) => {
->>>>>>> 2e68df1285d6738c21a927916d357a399b5fa82c
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     const formattedDate = formatDate(data.date);
@@ -165,11 +160,7 @@ class MoodAnalyticsErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoun
     return this.props.children;
   }
 }
-<<<<<<< HEAD
 // Main MoodAnalytics component
-=======
-
->>>>>>> 2e68df1285d6738c21a927916d357a399b5fa82c
 const MoodAnalytics = () => {
   const router = useRouter();
   const [showInfoDialog, setShowInfoDialog] = useState(false);
@@ -287,30 +278,11 @@ const MoodAnalytics = () => {
       if (highestSpendingMood) {
         insights.push(`You tend to spend more when you're feeling ${highestSpendingMood.replace('_', ' ').toLowerCase()}`);
       }
-<<<<<<< HEAD
-
-      // Highest spending mood
-      const spendingByMood = analyticsData.spendingCorrelation;
-      if (Object.keys(spendingByMood).length > 0) {
-        const [highestSpendingMood] = Object.entries(spendingByMood)
-          .sort((a, b) => (b[1].totalSpent / b[1].count) - (a[1].totalSpent / a[1].count))[0] || [''];
-        if (highestSpendingMood) {
-          insights.push(`You tend to spend more when you're feeling ${highestSpendingMood.replace('_', ' ').toLowerCase()}`);
-        }
-      }
-
-      // Avg mood intensity
-      const recentMoods = analyticsData.timelineData.slice(-7);
-      const averageMoodIntensity = recentMoods.reduce((sum, item) => sum + item.intensity, 0) / recentMoods.length;
-      insights.push(`Your average mood intensity over the past week is ${averageMoodIntensity.toFixed(1)} out of 10`);
-	  
-=======
     }
     // Average mood intensity over recent 7 days
     const recentMoods = analyticsData.timelineData.slice(-7);
     const averageMoodIntensity = recentMoods.reduce((sum, item) => sum + item.intensity, 0) / (recentMoods.length || 1);
     insights.push(`Your average mood intensity over the past week is ${averageMoodIntensity.toFixed(1)} out of 10`);
->>>>>>> 2e68df1285d6738c21a927916d357a399b5fa82c
     return insights;
   };
 

--- a/src/pages/moods.tsx
+++ b/src/pages/moods.tsx
@@ -105,7 +105,6 @@ const MoodsPage = () => {
                     </div>
                   ))}
                 </div>
-				{/* Lists recent moods with details (mood, intensity, notes, date)*/}
               ) : recentMoods.length > 0 ? (
                 recentMoods.map((mood) => (
                   <div key={mood.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
@@ -122,7 +121,6 @@ const MoodsPage = () => {
                       {new Date(mood.date).toLocaleDateString()}
                     </div>
                   </div>
-				  {/* Shows message if no moods are logged*/}
                 ))
               ) : (
                 <p className="text-gray-500 text-center">No recent moods logged</p>

--- a/src/pages/transactions.tsx
+++ b/src/pages/transactions.tsx
@@ -728,7 +728,6 @@ export default function Transactions() {
                         No transactions found
                       </TableCell>
                     </TableRow>
-					{/* Lists transactions with actions*/}
                   ) : (
                     transactions.map((transaction) => {
                       const Icon = categoryIcons[transaction.category.name] || DollarSign


### PR DESCRIPTION
### Motivation
- The app failed to build due to leftover merge conflict markers and invalid JSX placement/comments that broke parsing and ternary expressions in several page components.

### Description
- Removed unresolved merge conflict markers and consolidated `CustomTooltip` and the mood-insight logic in `src/pages/mood-analytics.tsx` to a single, safe implementation.
- Fixed invalid JSX placement in `src/pages/analytics.tsx` by moving the inline JSX comment inside the returned `<Layout>` tree and added the missing `useRouter` import.
- Removed JSX comments that appeared inside ternary expressions in `src/pages/moods.tsx` and `src/pages/transactions.tsx` so the loading/empty/mapped branches render correctly.
- Committed changes which update the four files: `src/pages/analytics.tsx`, `src/pages/mood-analytics.tsx`, `src/pages/moods.tsx`, and `src/pages/transactions.tsx`.

### Testing
- Ran a production build with `pnpm build` (Next.js production build) and it completed successfully.
- Observed that the build finished with unrelated warnings about pre-existing import/export mismatches (e.g. missing `formatCurrency` export and `withAuth`), which were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b410cd62b8832da0a8c5f675f093bd)